### PR TITLE
Update download tweet archive instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ beyond the [3,200 tweet limit](https://web.archive.org/web/20131019125213/https:
 
 ### Configure API access
 
-1. Open Twitter's [Application Management](https://apps.twitter.com/), and create a new Twitter app.
-2. Set the permissions of your app to *Read and Write*.
-3. Set the required environment variables:
+1. Open Twitter's [Application Management](https://apps.twitter.com/), and create
+  a new Twitter app.
+1. Set the permissions of your app to *Read and Write*.
+1. Set the required environment variables:
 
 ```bash
 TWITTER_CONSUMER_KEY="[your consumer key]"
@@ -18,12 +19,13 @@ TWITTER_ACCESS_TOKEN="[your access token]"
 TWITTER_ACCESS_TOKEN_SECRET="[your access token secret]"
 ```
 
-### Get your Twitter archive
+### Get your tweet archive
 
-1. Open your [account page](https://twitter.com/settings/account).
-2. Click 'Your Twitter archive', and a link to your archive will arrive per email.
-3. Follow the link in the email to download the archive.
-4. Unpack the archive, and move `tweets.csv` to the same directory as this script.
+1. Open your [Twitter account page](https://twitter.com/settings/account).
+1. Scroll to the bottom of the page, click 'Request your archive' (not 'Your Twitter
+  data' in the left sidebar!), and wait for the email to arrive.
+1. Follow the link in the email to download your Tweet archive.
+1. Unpack the archive, and move `tweets.csv` to the same directory as this script.
 
 ## Installation
 


### PR DESCRIPTION
This should instruct people to download the right archive (the one containing the CSV).

See: https://github.com/koenrh/delete-tweets/pull/5