### PR TITLE
Add support for the 'tweet.js' file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ export TWITTER_ACCESS_TOKEN_SECRET="[your access token secret]"
 
 ### Get your tweet archive
 
-1. Open your [Twitter account page](https://twitter.com/settings/account).
-1. Scroll to the bottom of the page, click 'Request your archive' (not 'Your Twitter
-  data' in the left sidebar!), and wait for the email to arrive.
-1. Follow the link in the email to download your Tweet archive.
-1. Unpack the archive, and move `tweets.csv` to the same directory as this script.
+1. Open the [Your Twitter data page](https://twitter.com/settings/your_twitter_data).
+1. Scroll to the 'Download your Twitter data' section at the bottom of the page.
+1. Click 'Request data', and wait for the email to arrive.
+1. Follow the link in the email to download your Tweet data.
+1. Unpack the archive, and move `tweet.js` to the same directory as this script.
 
 ## Getting started
 
@@ -72,13 +72,13 @@ pip install -r requirements.txt
 Then, for example, delete any tweet from _before_ January 1, 2018:
 
 ```bash
-python deletetweets.py -d 2018-01-01 tweets.csv
+python deletetweets.py -d 2018-01-01 tweet.js
 ```
 
 Or only delete all retweets:
 
 ```bash
-python deletetweets.py -r retweet tweets.csv
+python deletetweets.py -r retweet tweet.js
 ```
 
 ### Docker
@@ -100,12 +100,11 @@ prepending your command with a _single space_ (requires `$HISTCONTROL` to be set
 to `ignorespace` or `ignoreboth`).
 
 ```bash
-docker run --env TWITTER_CONSUMER_KEY="[your consumer key]" \
-  --env TWITTER_CONSUMER_SECRET="[your consumer secret]" \
-  --env TWITTER_ACCESS_TOKEN="[your access token]" \
-  --env TWITTER_ACCESS_TOKEN_SECRET="[your access token secret]"
-  --rm -it koenrh/delete-tweets \
-  -v $E:PWD":/app" -d 2018-01-01 /app/tweets.csv
+docker run --env TWITTER_CONSUMER_KEY="$TWITTER_CONSUMER_KEY=" \
+  --env TWITTER_CONSUMER_SECRET="$TWITTER_CONSUMER_SECRET=" \
+  --env TWITTER_ACCESS_TOKEN="$TWITTER_ACCESS_TOKEN=" \
+  --env TWITTER_ACCESS_TOKEN_SECRET="$TWITTER_ACCESS_TOKEN_SECRET=" \
+  --volume "$PWD:/app" --rm -it koenrh/delete-tweets -d 2018-01-01 /app/tweet.js
 ```
 
 You could make this command more easily accessible by putting it an executable,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 python-twitter==3.5
 python-dateutil==2.8.0
-backports.csv==1.0.6; python_version < '3.0'

--- a/test_deletetweets.py
+++ b/test_deletetweets.py
@@ -35,39 +35,39 @@ class FakeReader(object):
 
 class TestDeleteTweets(unittest.TestCase):
     def test_tweet_reader_retweet(self):
-        tweets = [{"tweet_id": "42", "retweeted_status_id": "200"},
-                  {"tweet_id": "43", "retweeted_status_id": ""},
-                  {"tweet_id": "49", "retweeted_status_id": ""},
-                  {"tweet_id": "44", "retweeted_status_id": "300"}]
+        tweets = [{"id_str": "42", "full_text": "RT @github \\o/"},
+                  {"id_str": "43", "full_text": ""},
+                  {"id_str": "49", "full_text": ""},
+                  {"id_str": "44", "full_text": "RT @google OK, Google"}]
 
-        expected = [{"tweet_id": "42"}, {"tweet_id": "44"}]
+        expected = [{"id_str": "42"}, {"id_str": "44"}]
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               restrict="retweet").read()):
-            self.assertEqual(expected[idx]['tweet_id'], val['tweet_id'])
+            self.assertEqual(expected[idx]["id_str"], val["id_str"])
 
     def test_tweet_reader_reply(self):
-        tweets = [{'tweet_id': '12', 'in_reply_to_status_id': ''},
-                  {'tweet_id': '14', 'in_reply_to_status_id': '200'},
-                  {'tweet_id': '16', 'in_reply_to_status_id': ''},
-                  {'tweet_id': '18', 'in_reply_to_status_id': '203'}]
+        tweets = [{"id_str": "12", "in_reply_to_user_id_str": ""},
+                  {"id_str": "14", "in_reply_to_user_id_str": "200"},
+                  {"id_str": "16", "in_reply_to_user_id_str": ""},
+                  {"id_str": "18", "in_reply_to_user_id_str": "203"}]
 
-        expected = [{"tweet_id": "14"}, {"tweet_id": "18"}]
+        expected = [{"id_str": "14"}, {"id_str": "18"}]
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               restrict="reply").read()):
-            self.assertEqual(expected[idx]['tweet_id'], val['tweet_id'])
+            self.assertEqual(expected[idx]["id_str"], val["id_str"])
 
     def test_tweet_reader_date(self):
-        tweets = [{"tweet_id": "21", "timestamp": "2013-03-06 20:22:06 +0000"},
-                  {"tweet_id": "22", "timestamp": "2014-03-06 20:22:06 +0000"}]
+        tweets = [{"id_str": "21", "created_at": "Wed March 06 20:22:06 +0000 2013"},
+                  {"id_str": "22", "created_at": "Thu March 05 20:22:06 +0000 2014"}]
 
-        expected = [{"tweet_id": "21"}]
+        expected = [{"id_str": "21"}]
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
-                                              date='2014-02-01').read()):
-            self.assertEqual(expected[idx]['tweet_id'], val['tweet_id'])
+                                              date="2014-02-01").read()):
+            self.assertEqual(expected[idx]["id_str"], val["id_str"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tweet.js
+++ b/tweet.js
@@ -1,0 +1,26 @@
+window.YTD.tweet.part0 = [ {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ ],
+    "urls" : [ {
+      "url" : "https://t.co/b3B6lv0mjm",
+      "expanded_url" : "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190501-nexus9k-sshkey",
+      "display_url" : "tools.cisco.com/security/cente…",
+      "indices" : [ "38", "61" ]
+    } ]
+  },
+  "display_text_range" : [ "0", "61" ],
+  "favorite_count" : "5",
+  "id_str" : "1124018454028267520",
+  "truncated" : false,
+  "retweet_count" : "1",
+  "id" : "1124018454028267520",
+  "possibly_sensitive" : false,
+  "created_at" : "Thu May 02 18:30:57 +0000 2019",
+  "favorited" : false,
+  "full_text" : "Another week, another Cisco backdoor. https://t.co/b3B6lv0mjm",
+  "lang" : "en"
+} ]

--- a/tweets.csv
+++ b/tweets.csv
@@ -1,2 +1,0 @@
-"tweet_id","in_reply_to_status_id","in_reply_to_user_id","timestamp","source","text","retweeted_status_id","retweeted_status_user_id","retweeted_status_timestamp","expanded_urls"
-"1","","","2014-01-01 00:00:00 +0000","<a href=""http://tapbots.com/software/tweetbot/mac"" rel=""nofollow"">Tweetbot for Mac</a>","Tweet","","","",""


### PR DESCRIPTION
This updates the script to work with the `tweet.js` file from the Twitter data export archive. The old `tweets.csv` is no longer available.

Fixes https://github.com/koenrh/delete-tweets/issues/35