### PR TITLE
Fix assertions that compare expected to actual results

### DIFF
--- a/test_deletetweets.py
+++ b/test_deletetweets.py
@@ -40,10 +40,14 @@ class TestDeleteTweets(unittest.TestCase):
                   {"id_str": "44", "full_text": "RT @google OK, Google"}]
 
         expected = [{"id_str": "42"}, {"id_str": "44"}]
+        actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               restrict="retweet").read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
+            actual.append(val)
+
+        self.assertEqual(len(expected), len(actual))
 
     def test_tweet_reader_reply(self):
         tweets = [{"id_str": "12", "in_reply_to_user_id_str": ""},
@@ -52,53 +56,73 @@ class TestDeleteTweets(unittest.TestCase):
                   {"id_str": "18", "in_reply_to_user_id_str": "203"}]
 
         expected = [{"id_str": "14"}, {"id_str": "18"}]
+        actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               restrict="reply").read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
+            actual.append(val)
+
+        self.assertEqual(len(expected), len(actual))
 
     def test_tweet_reader_date(self):
         tweets = [{"id_str": "21", "created_at": "Wed March 06 20:22:06 +0000 2013"},
                   {"id_str": "22", "created_at": "Thu March 05 20:22:06 +0000 2014"}]
 
         expected = [{"id_str": "21"}]
+        actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               date="2014-02-01").read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
+            actual.append(val)
+
+        self.assertEqual(len(expected), len(actual))
 
     def test_tweet_reader_spare(self):
         tweets = [{"id_str": "21"},
                   {"id_str": "22"},
                   {"id_str": "23"}]
 
-        expected = [{"id_str": "21"}, {"id_str": "22"}]
+        expected = [{"id_str": "21"}]
+        actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               spare=["22", "23"]).read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
+            actual.append(val)
+
+        self.assertEqual(len(expected), len(actual))
 
     def test_tweet_reader_likes(self):
         tweets = [{"id_str": "21", "favorite_count": 0},
                   {"id_str": "22", "favorite_count": 1},
                   {"id_str": "23", "favorite_count": 2}]
 
-        expected = [{"id_str": "21"}, {"id_str": "22"}]
+        expected = [{"id_str": "21"}]
+        actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               min_likes=1).read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
+            actual.append(val)
+
+        self.assertEqual(len(expected), len(actual))
 
     def test_tweet_reader_retweets(self):
         tweets = [{"id_str": "21", "retweet_count": 0},
                   {"id_str": "22", "retweet_count": 1},
                   {"id_str": "23", "retweet_count": 2}]
 
-        expected = [{"id_str": "21"}, {"id_str": "22"}]
+        expected = [{"id_str": "21"}]
+        actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
                                               min_retweets=1).read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
+            actual.append(val)
+
+        self.assertEqual(len(expected), len(actual))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As pointed out in #50, the tests did not actually verify that the actual and expected arrays actually matched. Which means that the tests would pass as long as the actual array was a subset of the expected array.

Fixes #50