### PR TITLE
Add long command-line options and follow Twitter's naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ pip install delete-tweets
 Then, for example, delete any tweet from _before_ January 1, 2018:
 
 ```bash
-delete-tweets -d 2018-01-01 tweet.js
+delete-tweets --until 2018-01-01 tweet.js
 ```
 
 Or only delete all retweets:
 
 ```bash
-delete-tweets -r retweet tweet.js
+delete-tweets --filter retweets tweet.js
 ```
 
 ### Spare tweets
@@ -87,11 +87,11 @@ delete-tweets -r retweet tweet.js
 You can optionally spare tweets by passing their `id_str`, setting a minimum amount of likes or retweets:
 
 ```bash
-delete-tweets -d 2018-01-01 tweet.js --spare-ids 21235434 23498723 23498723
+delete-tweets --until 2018-01-01 tweet.js --spare-ids 21235434 23498723 23498723
 ```
 
 Spare tweets that have at least 10 likes, or 5 retweets:
 
 ```bash
-delete-tweets -d 2018-01-01 tweet.js --spare-min-likes 10 --spare-min-retweets 5
+delete-tweets --until 2018-01-01 tweet.js --spare-min-likes 10 --spare-min-retweets 5
 ```

--- a/bin/delete-tweets
+++ b/bin/delete-tweets
@@ -9,9 +9,9 @@ __version__ = "1.0.0"
 
 def main():
     parser = argparse.ArgumentParser(description="Delete old tweets.")
-    parser.add_argument("-d", dest="date", required=True,
+    parser.add_argument("-d", "--until", dest="date", required=True,
                         help="Delete tweets until this date")
-    parser.add_argument("-r", dest="restrict", choices=["reply", "retweet"],
+    parser.add_argument("-r", "--filter", dest="restrict", choices=["reply", "retweet"],
                         help="Restrict to either replies or retweets")
     parser.add_argument("file", help="Path to the tweet.js file",
                         type=str)

--- a/bin/delete-tweets
+++ b/bin/delete-tweets
@@ -9,10 +9,9 @@ __version__ = "1.0.0"
 
 def main():
     parser = argparse.ArgumentParser(description="Delete old tweets.")
-    parser.add_argument("-d", "--until", dest="date", required=True,
-                        help="Delete tweets until this date")
-    parser.add_argument("-r", "--filter", dest="restrict", choices=["reply", "retweet"],
-                        help="Restrict to either replies or retweets")
+    parser.add_argument("--until", dest="date", help="Delete tweets until this date")
+    parser.add_argument("--filter", action="append", dest="filters", choices=["replies", "retweets"],
+                        help="Filter replies or retweets", default=[])
     parser.add_argument("file", help="Path to the tweet.js file",
                         type=str)
     parser.add_argument("--spare-ids", dest="spare_ids", help="A list of tweet ids to spare",
@@ -23,6 +22,10 @@ def main():
                         help="Spare tweets with more than the provided retweets", type=int, default=0)
     parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
+    # legacy options
+    parser.add_argument("-d", dest="date", help=argparse.SUPPRESS)
+    parser.add_argument("-r", dest="restrict", choices=["reply", "retweet"], help=argparse.SUPPRESS)
+
     args = parser.parse_args()
 
     if not ("TWITTER_CONSUMER_KEY" in os.environ and
@@ -32,7 +35,18 @@ def main():
         sys.stderr.write("Twitter API credentials not set.\n")
         exit(1)
 
-    deletetweets.delete(args.file, args.date, args.restrict, args.spare_ids, args.min_likes, args.min_retweets)
+    filters = []
+
+    if args.restrict == "reply":
+        filters.append("replies")
+    elif args.restrict == "retweet":
+        filters.append("retweets")
+
+    for f in args.filters:
+        if f not in filters:
+            filters.append(f)
+
+    deletetweets.delete(args.file, args.date, filters, args.spare_ids, args.min_likes, args.min_retweets)
 
 
 if __name__ == "__main__":

--- a/test_deletetweets.py
+++ b/test_deletetweets.py
@@ -43,7 +43,7 @@ class TestDeleteTweets(unittest.TestCase):
         actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
-                                              restrict="retweet").read()):
+                                              filters=["retweets"]).read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
             actual.append(val)
 
@@ -59,7 +59,7 @@ class TestDeleteTweets(unittest.TestCase):
         actual = []
 
         for idx, val in enumerate(TweetReader(FakeReader(tweets),
-                                              restrict="reply").read()):
+                                              filters=["replies"]).read()):
             self.assertEqual(expected[idx]["id_str"], val["id_str"])
             actual.append(val)
 


### PR DESCRIPTION
This aims to add more sensible names for the command-line options by following Twitter's naming convention for search operators more closely.

https://developer.twitter.com/en/docs/tweets/rules-and-filtering/overview/standard-operators

The old short CLI options will still work.