### PR TITLE
Remove support for Python 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1
@@ -21,15 +21,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
 
       - name: Lint with flake8
         run: |
-          pip install flake8
-          flake8 . --count --max-line-length=125 --statistics
+          python3 -m pip install flake8
+          python3 -m flake8 . --count --max-line-length=125 --statistics
 
       - name: Test with pytest
         run: |
-          pip install pytest
-          python -m pytest --verbose
+          python3 -m pip install pytest
+          python3 -m pytest --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `--since` option to delete tweets since a specific date [\#80](https://github.com/koenrh/delete-tweets/pull/80)
     ([@cyb3rsalih](https://github.com/cyb3rsalih))
+- Remove support for Python 2.7 [\#66](https://github.com/koenrh/delete-tweets/pull/66)
 
 ## v1.0.6
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ export TWITTER_ACCESS_TOKEN_SECRET="your_access_token_secret"
 
 ### Installation
 
-Install the tool using `pip`.
+Install the tool using [`pip`](https://pip.pypa.io/).
 
 ```bash
-pip install delete-tweets
+python3 -m pip install delete-tweets
 ```
 
 ### Usage

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,8 @@ setuptools.setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 2.7",
         "License :: OSI Approved :: ISC License (ISCL)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=2.7',
+    python_requires='>=3',
 )


### PR DESCRIPTION
Since Python 2.7 will reach [end of life on January 1, 2020](https://www.python.org/dev/peps/pep-0373/).